### PR TITLE
Add "paths" option to "Custom Autoloading"

### DIFF
--- a/guides/6.profiles.rst
+++ b/guides/6.profiles.rst
@@ -90,6 +90,9 @@ you want to autoload via ``behat.yml``:
     default:
         autoload:
             '': %paths.base%/app/features/bootstrap
+        suites:
+            default:
+                paths: [ %paths.base%/app/features ]
 
 If you wish to namespace your features (for example: to be PSR-1 complaint) you will need to add the namespace to the classes and also tell behat where to load them. Here ``contexts`` is an array of classes:
 
@@ -103,6 +106,7 @@ If you wish to namespace your features (for example: to be PSR-1 complaint) you 
             '': %paths.base%/app/features/bootstrap
         suites:
             default:
+                paths: [ %paths.base%/app/features ]
                 contexts: [My\Application\Namespace\Bootstrap\FeatureContext]
 
 .. note::


### PR DESCRIPTION
I have moved my features path on a recent project and the necessity to add "paths" for suites is not explicit in the current documentation.